### PR TITLE
Improve memory consumption and fix minor bugs

### DIFF
--- a/example-project/Assets/Encoder/EncodeMP3.cs
+++ b/example-project/Assets/Encoder/EncodeMP3.cs
@@ -47,7 +47,7 @@ public static class EncodeMP3
 		//bytesData array is twice the size of
 		//dataSource array because a float converted in Int16 is 2 bytes.
 
-		float rescaleFactor = 32767; //to convert float to Int16
+		const float rescaleFactor = 32767; //to convert float to Int16
 
 		for (int i = 0; i < samples.Length; i++) {
 			intData [i] = (short)(samples [i] * rescaleFactor);
@@ -56,7 +56,7 @@ public static class EncodeMP3
 			byteArr.CopyTo (bytesData, i * 2);
 		}
 
-		File.WriteAllBytes (path, ConvertWavToMp3 (bytesData,bitRate));
+		File.WriteAllBytes (path, ConvertWavToMp3 (bytesData, clip.frequency, clip.channels, bitRate));
 	}
 
 

--- a/example-project/Assets/Encoder/EncodeMP3.cs
+++ b/example-project/Assets/Encoder/EncodeMP3.cs
@@ -61,23 +61,15 @@ public static class EncodeMP3
 
 
 
-	private static byte[] ConvertWavToMp3 (byte[] wavFile, int bitRate)
+	static byte[] ConvertWavToMp3 (byte[] wavFile, int sampleRate, int channels, int bitRate)
 	{
 
 		var retMs = new MemoryStream ();
 		var ms = new MemoryStream (wavFile);
-		var rdr = new RawSourceWaveStream (ms, new WaveFormat ());
+		var rdr = new RawSourceWaveStream (ms, new WaveFormat (sampleRate, channels));
 		var wtr = new LameMP3FileWriter (retMs, rdr.WaveFormat, bitRate);
 
 		rdr.CopyTo (wtr);
 		return retMs.ToArray ();
-
-
-
 	}
-	
-	
-
-
-
 }


### PR DESCRIPTION
I tried to use your project. It's pretty cool, but I discovered a few bugs and memory leaks.

### No sample rate nor channels count passed to WaveFormat
If the audio file has a different channels or sample rate from default, the file gets corrupted or pitched.
Check here:
https://github.com/BeatUpir/Unity3D-save-audioClip-to-MP3/compare/master...ProGM:memory-leaks-and-bugs?expand=1#diff-29948ff81e2d2d14645d9059e72db0a8R62

### Reduce memory consumption

This snippet allocates a lot of data, inside the for loop:
```csharp
Byte[] byteArr = new Byte[2];		
byteArr = BitConverter.GetBytes (intData [i]);
```
I replaced it with a `Buffer.BlockCopy` call.

https://github.com/BeatUpir/Unity3D-save-audioClip-to-MP3/compare/master...ProGM:memory-leaks-and-bugs?expand=1#diff-29948ff81e2d2d14645d9059e72db0a8R52

### Added the possibility to be Unity-indipendent
Unity doesn't allow to access Unity-classes from inside threads, so you can't defer the mp3 conversion (and since it is pretty slow, it could be useful)

https://github.com/BeatUpir/Unity3D-save-audioClip-to-MP3/compare/master...ProGM:memory-leaks-and-bugs?expand=1#diff-29948ff81e2d2d14645d9059e72db0a8R32


I hope it could be helpful :)